### PR TITLE
Add optional `legend` query parameter to the trips map

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ url: /api/connectedcars_io/trips_map/<token>?days=7
 aspect_ratio: 75%
 ```
 
-Query parameters: `days` (default 7), `from`/`to` (`YYYY-MM-DD`, a custom date range that overrides `days`), `limit` (default 8, max 200 — the 8 newest trips get distinct colours, older ones render gray), `vin` (with multiple cars). The page itself has preset buttons (7/30/90/365 days) and a custom from–to date picker; it shows the total km for the selected span.
+Query parameters: `days` (default 7), `from`/`to` (`YYYY-MM-DD`, a custom date range that overrides `days`), `limit` (default 8, max 200 — the 8 newest trips get distinct colours, older ones render gray), `legend` (`true`/`false` or `1`/`0`, default true — set to false for a clean map with just the routes), `vin` (with multiple cars). The page itself has preset buttons (7/30/90/365 days) and a custom from–to date picker; it shows the total km for the selected span. With `legend=false` the panel and its controls are left out entirely and the map fills the frame, which suits small dashboard cards.
 
 ## Debugging
 It is possible to debug log the raw response from the API. This is done by setting up logging like below in configuration.yaml in Home Assistant. It is also possible to set the log level through a service call in UI.  

--- a/custom_components/connectedcars_io/map_view.py
+++ b/custom_components/connectedcars_io/map_view.py
@@ -63,7 +63,21 @@ EVENT_NAMES_DA = {
 }
 SEVERITY_NAMES_DA = {"high": "kraftig", "medium": "middel", "low": "let"}
 
+_TRUE = {"1", "true", "yes", "on"}
+_FALSE = {"0", "false", "no", "off"}
 
+
+def _parse_bool(value, default=True):
+    """Query flag to bool; missing or unrecognised falls back to default."""
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in _TRUE:
+        return True
+    if text in _FALSE:
+        return False
+    return default
+    
 def _parse_ts(value):
     """ISO-8601 string to epoch seconds, or None."""
     if not value:
@@ -73,14 +87,12 @@ def _parse_ts(value):
     except ValueError:
         return None
 
-
 def _parse_day(value):
     """YYYY-MM-DD string to an aware UTC datetime, or None."""
     try:
         return datetime.strptime(value, "%Y-%m-%d").replace(tzinfo=UTC)
     except (TypeError, ValueError):
         return None
-
 
 def _api_iso(dt):
     """Datetime to the API's ISO-8601 Zulu format."""
@@ -146,7 +158,7 @@ def _trip_path(trip):
     return path
 
 
-def build_payload(vehicle, trips, selection):
+def build_payload(vehicle, trips, selection, show_legend=True):
     """JSON-serializable payload embedded in the map page.
 
     selection is {"days": int|None, "from": "YYYY-MM-DD"|None, "to": ...} —
@@ -171,7 +183,7 @@ def build_payload(vehicle, trips, selection):
                 "events": _event_positions(trip),
             }
         )
-    return {"vehicle": vehicle.get("name"), "selection": selection, "trips": out}
+    return {"vehicle": vehicle.get("name"), "selection": selection, "showLegend": show_legend, "trips": out}
 
 
 def async_ensure_map_token(hass, entry):
@@ -215,6 +227,7 @@ class ConnectedCarsTripsMapView(HomeAssistantView):
         except ValueError:
             return web.Response(status=400, text="Bad days/limit")
         vin = request.query.get("vin")
+        show_legend = _parse_bool(request.query.get("legend"), True)
 
         # A from/to date range takes precedence over the days preset.
         from_q = request.query.get("from")
@@ -255,7 +268,7 @@ class ConnectedCarsTripsMapView(HomeAssistantView):
             )
             or []
         )
-        payload = build_payload(vehicle, trips, selection)
+        payload = build_payload(vehicle, trips, selection, show_legend)
         return web.Response(
             text=render_map_html(payload),
             content_type="text/html",
@@ -363,9 +376,10 @@ _MAP_HTML = """<!DOCTYPE html>
 "use strict";
 const DATA = __PAYLOAD__;
 const dark = window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches;
+const showLegend = DATA.showLegend !== false;
 
-const map = L.map("map", { zoomControl: false });
-L.control.zoom({ position: 'topright' }).addTo(map);
+const map = L.map("map", { zoomControl: !showLegend });
+if (showLegend) L.control.zoom({ position: 'topright' }).addTo(map);
 L.tileLayer(
   dark
     ? "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png"
@@ -389,6 +403,7 @@ const headline = sel.days != null
   ? "ture, seneste " + sel.days + " dage"
   : "ture, " + fmtDay(sel.from) + " – " + (sel.to ? fmtDay(sel.to) : "nu");
 const legend = document.getElementById("legend");
+if (!showLegend) legend.remove();
 
 const collapseBtn = document.createElement('span');
 collapseBtn.id = 'idCollapse';


### PR DESCRIPTION
## What

Adds a `legend` query parameter to the trips map view. It takes `true`/`false` or `1`/`0` and defaults to true, so existing URLs and dashboard cards behave exactly as before.

With `legend=false` the whole panel is left out: title, range buttons, from/to date picker, total km, trip rows and the glyph key. The routes, start markers and event markers are untouched, and the map fills the frame.

/api/connectedcars_io/trips_map/<token>?days=30&legend=false

## Why

The legend panel takes a fair bit of room, which is fine on a full-width view but crowds the map in a small dashboard card. This gives a clean route-only mode without needing a second view.

## How

- New `_parse_bool()` helper for boolean query flags. Accepts true/false, 1/0, yes/no and on/off, and falls back to the default on anything else.
- `get()` parses `legend` and passes it to `build_payload()` as `show_legend`, which defaults to True so other callers are unaffected.
- The flag reaches the page as `showLegend` in the JSON payload.
- The page detaches the legend node when the flag is false. Everything below still appends to it, but a detached node renders nothing and its listeners can't fire, so this stays a one line change rather than a guard on every append.
- README updated with the new parameter.

## Testing

- Default URL, unchanged from before.
- `legend=false` and `legend=0`, panel gone, routes and event markers intact.
- `legend=true`, `legend=1` and a nonsense value like `legend=maybe`, all show the panel.